### PR TITLE
Add support for multi-byte pathing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@michaelhart/meshcore-decoder",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@michaelhart/meshcore-decoder",
-      "version": "0.2.7",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@noble/ed25519": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@michaelhart/meshcore-decoder",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "TypeScript library for decoding MeshCore packets",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/decoder/packet-decoder.ts
+++ b/src/decoder/packet-decoder.ts
@@ -157,18 +157,30 @@ export class MeshCorePacketDecoder {
         offset += 4;
       }
 
-      // parse path
+      // parse path length byte (encodes hash size and hop count)
+      // Bits 7:6 = hash size selector: (path_len >> 6) + 1 = 1, 2, or 3 bytes per hop
+      // Bits 5:0 = hop count (0-63)
       if (bytes.length < offset + 1) {
         throw new Error('Packet too short for path length');
       }
-      const pathLength = bytes[offset];
+      const pathLenByte = bytes[offset];
+      const { hashSize: pathHashSize, hopCount: pathHopCount, byteLength: pathByteLength } = this.decodePathLenByte(pathLenByte);
+
+      if (pathHashSize === 4) {
+        throw new Error('Invalid path length byte: reserved hash size (bits 7:6 = 11)');
+      }
 
       if (includeStructure) {
-        let pathLengthDescription = `Path contains ${pathLength} bytes`;
-        if (routeType === RouteType.Direct || routeType === RouteType.TransportDirect) {
-          pathLengthDescription = `For "Direct" packets, this contains routing instructions. ${pathLength} bytes of routing instructions (decreases as packet travels)`;
+        const hashDesc = pathHashSize > 1 ? ` × ${pathHashSize}-byte hashes (${pathByteLength} bytes)` : '';
+        let pathLengthDescription: string;
+        if (pathHopCount === 0) {
+          pathLengthDescription = pathHashSize > 1 ? `No path data (${pathHashSize}-byte hash mode)` : 'No path data';
+        } else if (routeType === RouteType.Direct || routeType === RouteType.TransportDirect) {
+          pathLengthDescription = `${pathHopCount} hops${hashDesc} of routing instructions (decreases as packet travels)`;
         } else if (routeType === RouteType.Flood || routeType === RouteType.TransportFlood) {
-          pathLengthDescription = `${pathLength} bytes showing route taken (increases as packet floods)`;
+          pathLengthDescription = `${pathHopCount} hops${hashDesc} showing route taken (increases as packet floods)`;
+        } else {
+          pathLengthDescription = `Path contains ${pathHopCount} hops${hashDesc}`;
         }
 
         segments.push({
@@ -176,24 +188,48 @@ export class MeshCorePacketDecoder {
           description: pathLengthDescription,
           startByte: offset,
           endByte: offset,
-          value: `0x${pathLength.toString(16).padStart(2, '0')}`
+          value: `0x${pathLenByte.toString(16).padStart(2, '0')}`,
+          headerBreakdown: {
+            fullBinary: pathLenByte.toString(2).padStart(8, '0'),
+            fields: [
+              {
+                bits: '6-7',
+                field: 'Hash Size',
+                value: `${pathHashSize} byte${pathHashSize > 1 ? 's' : ''} per hop`,
+                binary: ((pathLenByte >> 6) & 0x03).toString(2).padStart(2, '0')
+              },
+              {
+                bits: '0-5',
+                field: 'Hop Count',
+                value: `${pathHopCount} hop${pathHopCount !== 1 ? 's' : ''}`,
+                binary: (pathLenByte & 63).toString(2).padStart(6, '0')
+              }
+            ]
+          }
         });
       }
       offset += 1;
 
-      if (bytes.length < offset + pathLength) {
+      if (bytes.length < offset + pathByteLength) {
         throw new Error('Packet too short for path data');
       }
 
-      // convert path data to hex strings
-      const pathBytes = bytes.subarray(offset, offset + pathLength);
-      const path: string[] | null = pathLength > 0 ? Array.from(pathBytes).map(byteToHex) : null;
+      // convert path data to grouped hex strings (one entry per hop)
+      const pathBytes = bytes.subarray(offset, offset + pathByteLength);
+      let path: string[] | null = null;
+      if (pathHopCount > 0) {
+        path = [];
+        for (let i = 0; i < pathHopCount; i++) {
+          const hopBytes = pathBytes.subarray(i * pathHashSize, (i + 1) * pathHashSize);
+          path.push(bytesToHex(hopBytes));
+        }
+      }
 
-      if (includeStructure && pathLength > 0) {
+      if (includeStructure && pathHopCount > 0) {
         if (payloadType === PayloadType.Trace) {
-          // TRACE packets have SNR values in path
+          // TRACE packets have SNR values in path (always single-byte entries)
           const snrValues = [];
-          for (let i = 0; i < pathLength; i++) {
+          for (let i = 0; i < pathByteLength; i++) {
             const snrRaw = bytes[offset + i];
             const snrSigned = snrRaw > 127 ? snrRaw - 256 : snrRaw;
             const snrDb = snrSigned / 4.0;
@@ -203,27 +239,27 @@ export class MeshCorePacketDecoder {
             name: 'Path SNR Data',
             description: `SNR values collected during trace: ${snrValues.join(', ')}`,
             startByte: offset,
-            endByte: offset + pathLength - 1,
-            value: bytesToHex(bytes.slice(offset, offset + pathLength))
+            endByte: offset + pathByteLength - 1,
+            value: bytesToHex(bytes.slice(offset, offset + pathByteLength))
           });
         } else {
           let pathDescription = 'Routing path information';
           if (routeType === RouteType.Direct || routeType === RouteType.TransportDirect) {
-            pathDescription = 'Routing instructions (bytes are stripped at each hop as packet travels to destination)';
+            pathDescription = `Routing instructions (${pathHashSize}-byte hashes stripped at each hop as packet travels to destination)`;
           } else if (routeType === RouteType.Flood || routeType === RouteType.TransportFlood) {
-            pathDescription = 'Historical route taken (bytes are added as packet floods through network)';
+            pathDescription = `Historical route taken (${pathHashSize}-byte hashes added as packet floods through network)`;
           }
 
           segments.push({
             name: 'Path Data',
             description: pathDescription,
             startByte: offset,
-            endByte: offset + pathLength - 1,
-            value: bytesToHex(bytes.slice(offset, offset + pathLength))
+            endByte: offset + pathByteLength - 1,
+            value: bytesToHex(bytes.slice(offset, offset + pathByteLength))
           });
         }
       }
-      offset += pathLength;
+      offset += pathByteLength;
 
       // extract payload
       const payloadBytes = bytes.subarray(offset);
@@ -358,7 +394,8 @@ export class MeshCorePacketDecoder {
         payloadType,
         payloadVersion,
         transportCodes,
-        pathLength,
+        pathLength: pathHopCount,
+        ...(pathHashSize > 1 ? { pathHashSize } : {}),
         path,
         payload: {
           raw: payloadHex,
@@ -489,13 +526,17 @@ export class MeshCorePacketDecoder {
       if (bytes.length < offset + 1) {
         errors.push('Packet too short for path length');
       } else {
-        const pathLength = bytes[offset];
+        const pathLenByte = bytes[offset];
+        const { hashSize, byteLength } = this.decodePathLenByte(pathLenByte);
         offset += 1;
-        
-        if (bytes.length < offset + pathLength) {
+
+        if (hashSize === 4) {
+          errors.push('Invalid path length byte: reserved hash size (bits 7:6 = 11)');
+        }
+        if (bytes.length < offset + byteLength) {
           errors.push('Packet too short for path data');
         }
-        offset += pathLength;
+        offset += byteLength;
       }
 
       // check if we have payload data
@@ -517,18 +558,18 @@ export class MeshCorePacketDecoder {
     // for TRACE packets, use the trace tag as hash
     if (payloadType === PayloadType.Trace && bytes.length >= 13) {
       let offset = 1;
-      
+
       // skip transport codes if present
       if (routeType === RouteType.TransportFlood || routeType === RouteType.TransportDirect) {
         offset += 4;
       }
-      
-      // skip path data
+
+      // skip path data (decode path_len byte for multi-byte hops)
       if (bytes.length > offset) {
-        const pathLen = bytes[offset];
-        offset += 1 + pathLen;
+        const { byteLength } = this.decodePathLenByte(bytes[offset]);
+        offset += 1 + byteLength;
       }
-      
+
       // extract trace tag
       if (bytes.length >= offset + 4) {
         const traceTag = (bytes[offset]) | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24);
@@ -539,16 +580,16 @@ export class MeshCorePacketDecoder {
     // for other packets, create hash from constant parts
     const constantHeader = (payloadType << 2) | (payloadVersion << 6);
     let offset = 1;
-    
+
     // skip transport codes if present
     if (routeType === RouteType.TransportFlood || routeType === RouteType.TransportDirect) {
       offset += 4;
     }
-    
-    // skip path data
+
+    // skip path data (decode path_len byte for multi-byte hops)
     if (bytes.length > offset) {
-      const pathLen = bytes[offset];
-      offset += 1 + pathLen;
+      const { byteLength } = this.decodePathLenByte(bytes[offset]);
+      offset += 1 + byteLength;
     }
     
     const payloadData = bytes.slice(offset);
@@ -571,6 +612,18 @@ export class MeshCorePacketDecoder {
     nodeKeys?: Record<string, string>;
   }): CryptoKeyStore {
     return new MeshCoreKeyStore(initialKeys);
+  }
+
+  /**
+   * Decode a path_len byte into hash size, hop count, and total byte length.
+   * Firmware reference: Packet.h lines 79-83
+   *   Bits 7:6 = hash size selector: (path_len >> 6) + 1 = 1, 2, or 3 bytes per hop
+   *   Bits 5:0 = hop count (0-63)
+   */
+  private static decodePathLenByte(pathLenByte: number): { hashSize: number; hopCount: number; byteLength: number } {
+    const hashSize = (pathLenByte >> 6) + 1;
+    const hopCount = pathLenByte & 63;
+    return { hashSize, hopCount, byteLength: hopCount * hashSize };
   }
 
 }

--- a/src/decoder/payload-decoders/path.ts
+++ b/src/decoder/payload-decoders/path.ts
@@ -3,17 +3,17 @@
 
 import { PathPayload } from '../../types/payloads';
 import { PayloadType, PayloadVersion } from '../../types/enums';
-import { byteToHex, bytesToHex } from '../../utils/hex';
+import { bytesToHex } from '../../utils/hex';
 
 export class PathPayloadDecoder {
   static decode(payload: Uint8Array): PathPayload | null {
     try {
       // Based on MeshCore payloads.md - Path payload structure:
-      // - path_length (1 byte)
-      // - path (variable length) - list of node hashes (one byte each)
+      // - path_len (1 byte, encoded: bits 7:6 = hash size selector, bits 5:0 = hop count)
+      // - path (variable length) - list of node hashes (pathHashSize bytes each)
       // - extra_type (1 byte) - bundled payload type
       // - extra (rest of data) - bundled payload content
-      
+
       if (payload.length < 2) {
         return {
           type: PayloadType.Path,
@@ -27,41 +27,61 @@ export class PathPayloadDecoder {
         };
       }
 
-      const pathLength = payload[0];
-      
-      if (payload.length < 1 + pathLength + 1) {
+      const pathLenByte = payload[0];
+      const pathHashSize = (pathLenByte >> 6) + 1;
+      const pathHopCount = pathLenByte & 63;
+      const pathByteLength = pathHopCount * pathHashSize;
+
+      if (pathHashSize === 4) {
         return {
           type: PayloadType.Path,
           version: PayloadVersion.Version1,
           isValid: false,
-          errors: [`Path payload too short (need ${1 + pathLength + 1} bytes for path length + path + extra type)`],
-          pathLength,
+          errors: ['Invalid path length byte: reserved hash size (bits 7:6 = 11)'],
+          pathLength: 0,
           pathHashes: [],
           extraType: 0,
           extraData: ''
         };
       }
 
-      // Parse path hashes (one byte each)
+      if (payload.length < 1 + pathByteLength + 1) {
+        return {
+          type: PayloadType.Path,
+          version: PayloadVersion.Version1,
+          isValid: false,
+          errors: [`Path payload too short (need ${1 + pathByteLength + 1} bytes for path length + path + extra type)`],
+          pathLength: pathHopCount,
+          ...(pathHashSize > 1 ? { pathHashSize } : {}),
+          pathHashes: [],
+          extraType: 0,
+          extraData: ''
+        };
+      }
+
+      // Parse path hashes (pathHashSize bytes each)
       const pathHashes: string[] = [];
-      for (let i = 0; i < pathLength; i++) {
-        pathHashes.push(byteToHex(payload[1 + i]));
+      for (let i = 0; i < pathHopCount; i++) {
+        const hashStart = 1 + i * pathHashSize;
+        const hashBytes = payload.subarray(hashStart, hashStart + pathHashSize);
+        pathHashes.push(bytesToHex(hashBytes));
       }
 
       // Parse extra type (1 byte after path)
-      const extraType = payload[1 + pathLength];
+      const extraType = payload[1 + pathByteLength];
 
       // Parse extra data (remaining bytes)
       let extraData = '';
-      if (payload.length > 1 + pathLength + 1) {
-        extraData = bytesToHex(payload.subarray(1 + pathLength + 1));
+      if (payload.length > 1 + pathByteLength + 1) {
+        extraData = bytesToHex(payload.subarray(1 + pathByteLength + 1));
       }
 
       return {
         type: PayloadType.Path,
         version: PayloadVersion.Version1,
         isValid: true,
-        pathLength,
+        pathLength: pathHopCount,
+        ...(pathHashSize > 1 ? { pathHashSize } : {}),
         pathHashes,
         extraType,
         extraData

--- a/src/decoder/payload-decoders/trace.ts
+++ b/src/decoder/payload-decoders/trace.ts
@@ -81,7 +81,8 @@ export class TracePayloadDecoder {
       }
       offset += 1;
 
-      // lower two flag bits encode bytes per trace hop hash: 1 << n => 1, 2, 4, 8
+      // v1.11+: lower two flag bits are trace path hash size: 1 << n => 1, 2, 4, 8
+      // Note: This is distinct from the path hash size in the packet header added in 1.14
       const pathHashSize = 1 << (flags & 0x03);
       if (payload.length < offset || (payload.length - offset) % pathHashSize !== 0) {
         return {

--- a/src/decoder/payload-decoders/trace.ts
+++ b/src/decoder/payload-decoders/trace.ts
@@ -4,7 +4,7 @@
 import { TracePayload } from '../../types/payloads';
 import { PayloadSegment } from '../../types/packet';
 import { PayloadType, PayloadVersion } from '../../types/enums';
-import { numberToHex, byteToHex, bytesToHex } from '../../utils/hex';
+import { numberToHex, bytesToHex } from '../../utils/hex';
 
 export class TracePayloadDecoder {
   static decode(payload: Uint8Array, pathData?: string[] | null, options?: { includeSegments?: boolean; segmentOffset?: number }): TracePayload & { segments?: PayloadSegment[] } | null {
@@ -81,12 +81,30 @@ export class TracePayloadDecoder {
       }
       offset += 1;
 
+      // lower two flag bits encode bytes per trace hop hash: 1 << n => 1, 2, 4, 8
+      const pathHashSize = 1 << (flags & 0x03);
+      if (payload.length < offset || (payload.length - offset) % pathHashSize !== 0) {
+        return {
+          type: PayloadType.Trace,
+          version: PayloadVersion.Version1,
+          isValid: false,
+          errors: [
+            `Trace payload path bytes (${payload.length - offset}) do not align to ${pathHashSize}-byte hashes`,
+          ],
+          traceTag,
+          authCode,
+          flags,
+          ...(pathHashSize > 1 ? { pathHashSize } : {}),
+          pathHashes: [],
+        };
+      }
+
       // remaining bytes are path hashes (node hashes in the trace path)
       const pathHashes: string[] = [];
       const pathHashesStart = offset;
-      while (offset < payload.length) {
-        pathHashes.push(byteToHex(payload[offset]));
-        offset++;
+      while (offset + pathHashSize <= payload.length) {
+        pathHashes.push(bytesToHex(payload.subarray(offset, offset + pathHashSize)));
+        offset += pathHashSize;
       }
 
       if (options?.includeSegments && pathHashes.length > 0) {
@@ -118,6 +136,7 @@ export class TracePayloadDecoder {
         traceTag,
         authCode,
         flags,
+        ...(pathHashSize > 1 ? { pathHashSize } : {}),
         pathHashes,
         snrValues
       };

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -14,6 +14,7 @@ export interface DecodedPacket {
   // transport and routing
   transportCodes?: [number, number];
   pathLength: number;
+  pathHashSize?: number;
   path: string[] | null;
   
   // payload data

--- a/src/types/payloads.ts
+++ b/src/types/payloads.ts
@@ -97,6 +97,7 @@ export interface AckPayload extends BasePayload {
 
 export interface PathPayload extends BasePayload {
   pathLength: number;
+  pathHashSize?: number;
   pathHashes: string[];
   extraType: number;
   extraData: string;

--- a/src/types/payloads.ts
+++ b/src/types/payloads.ts
@@ -32,6 +32,7 @@ export interface TracePayload extends BasePayload {
   traceTag: string;
   authCode: number;
   flags: number;
+  pathHashSize?: number;
   pathHashes: string[];
   snrValues?: number[]; // from path field for TRACE packets
 }

--- a/tests/ack-path.test.ts
+++ b/tests/ack-path.test.ts
@@ -5,6 +5,8 @@ import { MeshCorePacketDecoder, PayloadType, AckPayload, PathPayload } from '../
 
 const ACK_PACKET = '0D04B891647EBB40BA70';
 const PATH_PACKET = '2105F464C77E411279399EFE1942B8A3FFA10F54D9C602FF2C8CF4';
+const MULTIBYTE_ACK_PACKET = '0E41AABB11223344';
+const MULTIBYTE_PATH_PACKET = '210042AABBCCDDEEFF00';
 
 describe('Ack/Path Packet Decoding', () => {
   describe('Ack Packet', () => {
@@ -22,6 +24,24 @@ describe('Ack/Path Packet Decoding', () => {
         
         // Validate Ack payload structure with hex breakdown
         expect(ackPayload.checksum).toBe('BB40BA70'); // Bytes 0-3: CRC checksum as hex
+      } else {
+        fail('Ack payload not decoded correctly');
+      }
+    });
+
+    it('should decode packet-level multi-byte paths correctly', () => {
+      const result = MeshCorePacketDecoder.decode(MULTIBYTE_ACK_PACKET);
+
+      expect(result.isValid).toBe(true);
+      expect(result.payloadType).toBe(PayloadType.Ack);
+      expect(result.pathLength).toBe(1);
+      expect(result.pathHashSize).toBe(2);
+      expect(result.path).toEqual(['AABB']);
+
+      if (result.payload.decoded && 'type' in result.payload.decoded && result.payload.decoded.type === PayloadType.Ack) {
+        const ackPayload = result.payload.decoded as AckPayload;
+        expect(ackPayload.isValid).toBe(true);
+        expect(ackPayload.checksum).toBe('11223344');
       } else {
         fail('Ack payload not decoded correctly');
       }
@@ -52,6 +72,28 @@ describe('Ack/Path Packet Decoding', () => {
         ]); // Bytes 1-18: path hashes
         expect(pathPayload.extraType).toBe(244); // Byte 19: 0xF4 = 244
         expect(pathPayload.extraData).toBe(''); // No extra data after extraType
+      } else {
+        fail('Path payload not decoded correctly');
+      }
+    });
+
+    it('should decode multi-byte path payload hashes correctly', () => {
+      const result = MeshCorePacketDecoder.decode(MULTIBYTE_PATH_PACKET);
+
+      expect(result.isValid).toBe(true);
+      expect(result.payloadType).toBe(PayloadType.Path);
+      expect(result.pathLength).toBe(0);
+      expect(result.path).toBeNull();
+
+      if (result.payload.decoded && 'type' in result.payload.decoded && result.payload.decoded.type === PayloadType.Path) {
+        const pathPayload = result.payload.decoded as PathPayload;
+
+        expect(pathPayload.isValid).toBe(true);
+        expect(pathPayload.pathLength).toBe(2);
+        expect(pathPayload.pathHashSize).toBe(2);
+        expect(pathPayload.pathHashes).toEqual(['AABB', 'CCDD']);
+        expect(pathPayload.extraType).toBe(0xEE);
+        expect(pathPayload.extraData).toBe('FF00');
       } else {
         fail('Path payload not decoded correctly');
       }

--- a/tests/grouptext-decryption.test.ts
+++ b/tests/grouptext-decryption.test.ts
@@ -1,5 +1,121 @@
 import { MeshCorePacketDecoder, RouteType, PayloadType, PayloadVersion, GroupTextPayload } from '../src';
 
+// #bot channel key for multi-byte hop tests
+const BOT_CHANNEL_KEY = 'eb50a1bcb3e4e5d7bf69a57c9dada211';
+
+describe('Multi-byte Hop Labels', () => {
+  it('should decode 3-byte hashes with 3 hops (path_len = 0x83)', () => {
+    const hexData = '15833fa002860ccae0eed9ca78b9ab0775d477c1f6490a398bf4edc75240';
+
+    const keyStore = MeshCorePacketDecoder.createKeyStore({
+      channelSecrets: [BOT_CHANNEL_KEY]
+    });
+
+    const packet = MeshCorePacketDecoder.decode(hexData, { keyStore });
+
+    expect(packet.isValid).toBe(true);
+    expect(packet.routeType).toBe(RouteType.Flood);
+    expect(packet.payloadType).toBe(PayloadType.GroupText);
+
+    // Path encoding: 0x83 = hash_size=3, hop_count=3 (only set when > 1)
+    expect(packet.pathHashSize).toBe(3);
+    expect(packet.pathLength).toBe(3);
+    expect(packet.path).toEqual(['3FA002', '860CCA', 'E0EED9']);
+
+    // Should decrypt with #bot key
+    const groupText = packet.payload.decoded as GroupTextPayload;
+    expect(groupText.isValid).toBe(true);
+    expect(groupText.decrypted).toBeDefined();
+    expect(groupText.decrypted?.sender).toBe('Roy B V4');
+    expect(groupText.decrypted?.message).toBe('P');
+  });
+
+  it('should decode 2-byte hashes with 0 hops (path_len = 0x40)', () => {
+    const hexData = '1540cab3b15626481a5ba64247ab25766e410b026e0678a32da9f0c3946fae5b714cab170f';
+
+    const keyStore = MeshCorePacketDecoder.createKeyStore({
+      channelSecrets: [BOT_CHANNEL_KEY]
+    });
+
+    const packet = MeshCorePacketDecoder.decode(hexData, { keyStore });
+
+    expect(packet.isValid).toBe(true);
+    expect(packet.routeType).toBe(RouteType.Flood);
+    expect(packet.payloadType).toBe(PayloadType.GroupText);
+
+    // Path encoding: 0x40 = hash_size=2, hop_count=0 (only set when > 1)
+    expect(packet.pathHashSize).toBe(2);
+    expect(packet.pathLength).toBe(0);
+    expect(packet.path).toBeNull();
+
+    // Should decrypt with #bot key
+    const groupText = packet.payload.decoded as GroupTextPayload;
+    expect(groupText.isValid).toBe(true);
+    expect(groupText.decrypted).toBeDefined();
+    expect(groupText.decrypted?.sender).toBe('Howl 👾');
+    expect(groupText.decrypted?.message).toBe('prefix 0101');
+  });
+
+  it('should decode single-byte hops (path_len = 0x00) for regression', () => {
+    const hexData = '150013752F15A1BF3C018EB1FC4F26B5FAEB417BB0F1AE8FF07655484EBAA05CB9A927D689';
+
+    const packet = MeshCorePacketDecoder.decode(hexData);
+
+    expect(packet.isValid).toBe(true);
+    expect(packet.routeType).toBe(RouteType.Flood);
+    expect(packet.payloadType).toBe(PayloadType.GroupText);
+
+    // Path encoding: 0x00 = hash_size=1, hop_count=0 (backward compatible, field omitted)
+    expect(packet.pathHashSize).toBeUndefined();
+    expect(packet.pathLength).toBe(0);
+    expect(packet.path).toBeNull();
+
+    // Payload should parse correctly
+    const groupText = packet.payload.decoded as GroupTextPayload;
+    expect(groupText.isValid).toBe(true);
+    expect(groupText.channelHash).toBe('13');
+  });
+
+  it('should analyze structure of multi-byte hop packet', () => {
+    const hexData = '15833fa002860ccae0eed9ca78b9ab0775d477c1f6490a398bf4edc75240';
+    const structure = MeshCorePacketDecoder.analyzeStructure(hexData);
+
+    // Path Length segment should have bit-level breakdown
+    const pathLenSegment = structure.segments.find(s => s.name === 'Path Length');
+    expect(pathLenSegment).toBeDefined();
+    expect(pathLenSegment!.value).toBe('0x83');
+    expect(pathLenSegment!.headerBreakdown).toBeDefined();
+    expect(pathLenSegment!.headerBreakdown!.fields).toHaveLength(2);
+    expect(pathLenSegment!.headerBreakdown!.fields[0].field).toBe('Hash Size');
+    expect(pathLenSegment!.headerBreakdown!.fields[0].value).toBe('3 bytes per hop');
+    expect(pathLenSegment!.headerBreakdown!.fields[1].field).toBe('Hop Count');
+    expect(pathLenSegment!.headerBreakdown!.fields[1].value).toBe('3 hops');
+
+    // Path Data segment should show grouped hashes
+    const pathDataSegment = structure.segments.find(s => s.name === 'Path Data');
+    expect(pathDataSegment).toBeDefined();
+    expect(pathDataSegment!.value).toBe('3FA002860CCAE0EED9');
+    expect(pathDataSegment!.description).toContain('3-byte hashes');
+    expect(pathDataSegment!.description).toContain('Historical route taken');
+
+    // Byte ranges should be contiguous
+    let expectedByte = 0;
+    for (const segment of structure.segments) {
+      expect(segment.startByte).toBe(expectedByte);
+      expectedByte = segment.endByte + 1;
+    }
+  });
+
+  it('should reject reserved hash size (bits 7:6 = 11)', () => {
+    // path_len = 0xC1 = bits 7:6 = 11 (reserved), hop_count = 1
+    const hexData = '15C1FF00';
+    const packet = MeshCorePacketDecoder.decode(hexData);
+    expect(packet.isValid).toBe(false);
+    expect(packet.errors).toBeDefined();
+    expect(packet.errors![0]).toContain('reserved hash size');
+  });
+});
+
 describe('GroupText Decryption', () => {
   it('should decrypt public channel message from Tree', () => {
     const hexData = '150011C3C1354D619BAE9590E4D177DB7EEAF982F5BDCF78005D75157D9535FA90178F785D';

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -52,4 +52,25 @@ describe('Trace Packets', () => {
       expect(trace.errors).toBeDefined();
     }
   });
+
+  it('should decode multibyte trace path hashes from flags', () => {
+    const hexData = '260130040302010A0B0C0D01AABBCCDD';
+
+    const packet = MeshCorePacketDecoder.decode(hexData);
+
+    expect(packet.isValid).toBe(true);
+    expect(packet.routeType).toBe(RouteType.Direct);
+    expect(packet.payloadType).toBe(PayloadType.Trace);
+    expect(packet.pathLength).toBe(1);
+    expect(packet.path).toEqual(['30']);
+
+    const trace = packet.payload.decoded as TracePayload;
+    expect(trace.isValid).toBe(true);
+    expect(trace.traceTag).toBe('01020304');
+    expect(trace.authCode).toBe(0x0d0c0b0a);
+    expect(trace.flags).toBe(1);
+    expect(trace.pathHashSize).toBe(2);
+    expect(trace.pathHashes).toEqual(['AABB', 'CCDD']);
+    expect(trace.snrValues).toEqual([12]);
+  });
 });


### PR DESCRIPTION
Hello! Thanks for such a lovely library! It powers some great flows in some tools I've made.

This is a minimal case (and, unfortunately, minimally tested, because I don't have access to many multibyte path packets) to add multi-byte pathing support to meshcore-decoder (this would close #5, and make this lib firmware 1.14 ready). All tests pass, including the new ones with actual from-the-message packets (again, only a couple group-messages; would love to add more if you have any).

This was written with LLM assistance, and it did what it tends to do of leaving little tidbits of improvements of error messages etc. as it goes. This may be welcome, or feel free to reject in favor of a more minimalist patch (or no patch at all, if this isn't something you plan to support).